### PR TITLE
Split run

### DIFF
--- a/submitscripts/split_gms-artic.sh
+++ b/submitscripts/split_gms-artic.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+#CLI
+FASTQDIR=$1
+TEMPFASTQ=$2
+ARTICDIR=$3
+ARTICOUTPUT=$4
+ARTICPREFIX=$5
+CHUNKSIZE=${6-4}
+
+### Sanity checks
+# Does tempdir exist? 
+if [ ! -d $TEMPFASTQ ]; then
+    echo "Directory $TEMPFASTQ DOES NOT exists. Please create it."
+    exit 1
+fi
+
+# Is temp dir empty?
+if [ "$(ls -A $TEMPFASTQ)" ]; then
+    echo "$TEMPFASTQ is not empty, please correct this."
+    exit 1
+fi
+
+# Are there any FASTQ files in the FASTQDIR?
+if [ $(ls ${FASTQDIR}/*.fastq.gz | wc -l) -lt 1 ]; then
+    echo "No files with ending .fastq.gz found in $FASTQDIR"
+    exit 1
+fi
+
+#Is BASH version 4 or higher (To use negative array indecies
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+    echo "BASH version < 4, won't work!"
+    exit 1
+fi
+
+#Set up some counters
+COUNTER=0
+RESCOUNT=1
+
+#Load in al lfiles to process into an array
+FASTQS=($FASTQDIR/*fastq.gz)
+
+for FASTQ in ${FASTQS[@]}; do
+    let COUNTER=COUNTER+1
+    rsync -P $FASTQ ${TEMPFASTQ}/ 
+
+    #Run CHUNKSIZE num of samples at once
+    if [[ $COUNTER -gt $CHUNKSIZE-1 ]]; then
+	#Run pipeline
+	echo "nextflow run ${ARTICDIR}/main.nf -profile singularity,sge --illumina --prefix $ARTICPREFIX --directory $TEMPFASTQ --outdir ${ARTICOUTPUT}-$RESCOUNT"
+
+	#Reset counters
+	let RESCOUNT=RESCOUNT+1
+	COUNTER=0
+	
+	#Remove temp data
+	rm $TEMPFASTQ/*.fastq.gz
+    fi
+
+    #Run again for all remaining samples
+    if [ $FASTQ == ${FASTQS[-1]} ] && [ $COUNTER -gt 0 ]; then
+	echo "nextflow run ${ARTICDIR}/main.nf -profile singularity,sge --illumina --prefix $ARTICPREFIX --directory $TEMPFASTQ --outdir ${ARTICOUTPUT}-$RESCOUNT"
+	rm $TEMPFASTQ/*.fastq.gz
+    fi
+
+
+done
+

--- a/submitscripts/split_gms-artic.sh
+++ b/submitscripts/split_gms-artic.sh
@@ -47,7 +47,7 @@ for FASTQ in ${FASTQS[@]}; do
     #Run CHUNKSIZE num of samples at once
     if [[ $COUNTER -gt $CHUNKSIZE-1 ]]; then
 	#Run pipeline
-	echo "nextflow run ${ARTICDIR}/main.nf -profile singularity,sge --illumina --prefix $ARTICPREFIX --directory $TEMPFASTQ --outdir ${ARTICOUTPUT}-$RESCOUNT"
+	nextflow run ${ARTICDIR}/main.nf -profile singularity,sge --illumina --prefix $ARTICPREFIX --directory $TEMPFASTQ --outdir ${ARTICOUTPUT}-$RESCOUNT
 
 	#Reset counters
 	let RESCOUNT=RESCOUNT+1
@@ -59,7 +59,7 @@ for FASTQ in ${FASTQS[@]}; do
 
     #Run again for all remaining samples
     if [ $FASTQ == ${FASTQS[-1]} ] && [ $COUNTER -gt 0 ]; then
-	echo "nextflow run ${ARTICDIR}/main.nf -profile singularity,sge --illumina --prefix $ARTICPREFIX --directory $TEMPFASTQ --outdir ${ARTICOUTPUT}-$RESCOUNT"
+	nextflow run ${ARTICDIR}/main.nf -profile singularity,sge --illumina --prefix $ARTICPREFIX --directory $TEMPFASTQ --outdir ${ARTICOUTPUT}-$RESCOUNT
 	rm $TEMPFASTQ/*.fastq.gz
     fi
 

--- a/submitscripts/split_gms-artic.sh
+++ b/submitscripts/split_gms-artic.sh
@@ -74,11 +74,17 @@ if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
     exit 1
 fi
 
+#Is there a main.nf in ARTICDIR
+if [ ! -f "${ARTICDIR}/main.nf" ]; then
+    echo "Could not find a main.nf in $ARTICDIR."
+    exit 1
+fi
+
 #Set up some counters
 COUNTER=0
 RESCOUNT=1
 
-#Load in al lfiles to process into an array
+#Load in all files to process into an array
 FASTQS=($FASTQDIR/*fastq.gz)
 
 for FASTQ in ${FASTQS[@]}; do


### PR DESCRIPTION
This is a tiny script to split a directory of fastq files into smaller chunks and run the gms-artic pipeline on all chunks. This was mainly made to circumvent the current problems of too may samples causing the system to crash.